### PR TITLE
Fixed Xbox 360 section of the Teleoperation Wiki

### DIFF
--- a/docs/source/teleoperation.rst
+++ b/docs/source/teleoperation.rst
@@ -83,7 +83,7 @@ PS3 Joystick
 XBOX 360 Joystick
 -----------------
 
-[``Remote PC``] Connect the PS3 Joystick to the PC via the Bluetooth.
+[``Remote PC``] Connect the XBOX 360 Joystick to the PC via the Wireless Adapter or the USB cable.
 
 [``Remote PC``] Install the packages for the teleoperation using XBOX 360 joystick.
 


### PR DESCRIPTION
Changed the PS3 instructions in the Xbox 360 instruction section to Xbox 360 instructions.